### PR TITLE
Implement FocusBuddy execution layer with check-ins, transitions, and presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ productivity gurus think it should.
 orchestration pipeline. Each agent handles one thing well, so you're not
 overwhelmed by a single "do everything" AI:
 
-| Agent          | What They Do For You                                                                                                                                          |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Planner**    | Breaks down overwhelming projects into manageable pieces. Limits choices when decision fatigue is high.                                                       |
-| **Chronos**    | Schedules tasks during your peak hours, buffers time estimates for time blindness, checks calendar conflicts, and learns from your estimates.                 |
-| **Guardian**   | Monitors your wellness proactively -- activates low-energy mode on your tough days, tracks breaks, detects burnout, and watches for overwork under deadlines. |
-| **Mentor**     | Adapts encouragement to your preferred tone, celebration style, and verbosity. Gets gentler on hard days and supportive when deadlines press.                 |
-| **Scribe**     | Remembers important details so your working memory doesn't have to.                                                                                           |
-| **Liaison**    | Helps draft emails and messages when words are hard -- activates automatically when deadlines are at risk.                                                    |
-| **FocusBuddy** | Creates focus sessions matched to your preferred duration and focus style (hyperfocus, variable, short-burst). Shortens sessions and adds breaks on low days. |
+| Agent          | What They Do For You                                                                                                                                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Planner**    | Breaks down overwhelming projects into manageable pieces. Limits choices when decision fatigue is high.                                                                                                                                                      |
+| **Chronos**    | Schedules tasks during your peak hours, buffers time estimates for time blindness, checks calendar conflicts, and learns from your estimates.                                                                                                                |
+| **Guardian**   | Monitors your wellness proactively -- activates low-energy mode on your tough days, tracks breaks, detects burnout, and watches for overwork under deadlines.                                                                                                |
+| **Mentor**     | Adapts encouragement to your preferred tone, celebration style, and verbosity. Gets gentler on hard days and supportive when deadlines press.                                                                                                                |
+| **Scribe**     | Remembers important details so your working memory doesn't have to.                                                                                                                                                                                          |
+| **Liaison**    | Helps draft emails and messages when words are hard -- activates automatically when deadlines are at risk.                                                                                                                                                   |
+| **FocusBuddy** | Your execution companion — creates focus sessions, provides mid-session check-ins adapted to focus style, guides task transitions based on transition difficulty, tracks momentum, generates session retrospectives, and offers body-doubling presence mode. |
 
 Every agent reads your `UserProfile` to personalize its behavior -- your peak
 hours, focus style, time blindness, decision fatigue, low-energy days, tone,
@@ -267,13 +267,19 @@ authentication, session management, and logging.
 - [x] `low_energy_mode` signal wired to FocusBuddy, Chronos, and Mentor
 - [x] `deadline_at_risk` signal wired to Guardian and Mentor
 
+**v0.6 -- Execution Layer** (done)
+
+- [x] Mid-session check-ins adapted to `focus_style` and `transition_difficulty`
+- [x] Transition support with scaffolding scaled to `transition_difficulty`
+- [x] Progress momentum tracking with `momentum_high`/`stalling`/`recovering` signals
+- [x] Session retrospectives with completion ratio, timing accuracy, restart points
+- [x] Body-doubling presence mode via CLI (`proximal focus --body-double`) and MCP
+
 **Next**
 
 - [x] Full calendar API integration (Google / Outlook) — `CalendarProvider`
       abstraction with conflict detection, Google (service account) and Outlook
       (Microsoft Graph) providers via optional `[calendar]` extra
-- [ ] Deepen execution layer (mid-session check-ins, transition support,
-      momentum tracking, body doubling)
 - [ ] Emotional intelligence (mood-adaptive tone, frustration detection)
 - [ ] Adaptive scaffolding (competence tracking, dynamic support levels)
 - [ ] Mobile companion app

--- a/apps/cli.py
+++ b/apps/cli.py
@@ -730,7 +730,7 @@ def focus(
         False, "--body-double", "-b", help="Enable body-doubling presence mode"
     ),
     duration: int = typer.Option(
-        25, "--duration", "-d", help="Session length in minutes"
+        25, "--duration", "-d", min=1, help="Session length in minutes"
     ),
     style: str = typer.Option(
         "variable",

--- a/apps/cli.py
+++ b/apps/cli.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import os
 import sys
+import time
 from typing import Dict, List, Optional
 
 import httpx
@@ -104,11 +105,12 @@ def plan(
     ),
 ):
     """
-    Transform a goal or idea into a structured project plan with tasks and sprints.
+    Transform a goal or idea into a structured project plan with tasks and
+    sprints.
 
-    By default, calls the planning pipeline directly without needing a running server.
-    Use --server to route through the API server instead.
-    Use --interactive for a conversational planning experience where PlannerAgent
+    By default, calls the planning pipeline directly without needing a running
+    server. Use --server to route through the API server instead. Use
+    --interactive for a conversational planning experience where PlannerAgent
     asks clarifying questions to create a more detailed and personalized plan.
     Use --energy to adapt plan complexity to your current energy level.
     """
@@ -397,7 +399,8 @@ def preferences(
     """
     View or update your planning preferences.
 
-    These preferences help PlannerAgent create personalized plans that match your work style.
+    These preferences help PlannerAgent create personalized plans that match
+    your work style.
     """
     try:
         if any([sprint_weeks, work_hours, tone, task_size]):
@@ -573,8 +576,8 @@ def wellness(
     """
     Show wellness insights from cross-session pattern detection.
 
-    Guardian agent tracks breaks, work duration, and late sessions to
-    identify burnout risk and provide actionable recommendations.
+    Guardian agent tracks breaks, work duration, and late sessions to identify
+    burnout risk and provide actionable recommendations.
     """
     from packages.core.capabilities.wellness import get_wellness_summary
 
@@ -627,8 +630,9 @@ def workflow(
     """
     Manage autonomous workflows.
 
-    Workflows run agents on schedules or in response to events.
-    Built-in workflows: daily_planning, proactive_checkin, weekly_status, adaptive_learning.
+    Workflows run agents on schedules or in response to events. Built-in
+    workflows: daily_planning, proactive_checkin, weekly_status,
+    adaptive_learning.
     """
     from packages.core.workflows.builtins import get_builtin_workflows
 
@@ -687,8 +691,8 @@ def analytics(
     """
     View analytics and productivity insights.
 
-    Aggregates task completion rates, energy patterns, estimate accuracy,
-    focus session adherence, and burnout risk indicators.
+    Aggregates task completion rates, energy patterns, estimate accuracy, focus
+    session adherence, and burnout risk indicators.
     """
     from packages.core.analytics.aggregator import AnalyticsAggregator
 
@@ -741,8 +745,8 @@ def focus(
     """
     Start a focus session with optional body-doubling presence mode.
 
-    Body doubling provides quiet periodic presence signals — like a
-    study buddy sitting across the table.
+    Body doubling provides quiet periodic presence signals — like a study buddy
+    sitting across the table.
     """
     from packages.core.agents.focusbuddy import FocusBuddyAgent
 
@@ -762,11 +766,10 @@ def focus(
             console.print(
                 f"  [cyan]{tick['message']}[/cyan]  (check-in every {interval}min)"
             )
-            import time
-
             while elapsed < duration:
-                time.sleep(min(interval * 60, (duration - elapsed) * 60))
-                elapsed += interval
+                step = min(interval, duration - elapsed)
+                time.sleep(step * 60)
+                elapsed += step
                 if elapsed >= duration:
                     break
                 tick = buddy.build_presence_tick(style, energy, elapsed_minutes=elapsed)
@@ -792,8 +795,8 @@ def mcp_serve():
     """
     Start proximal as an MCP (Model Context Protocol) server.
 
-    This exposes proximal's planning tools to any MCP client such as
-    Claude Desktop, VS Code, or Cursor via stdio transport.
+    This exposes proximal's planning tools to any MCP client such as Claude
+    Desktop, VS Code, or Cursor via stdio transport.
     """
     try:
         from apps.mcp_server import main as mcp_main

--- a/apps/cli.py
+++ b/apps/cli.py
@@ -720,6 +720,74 @@ def analytics(
 
 
 @app.command()
+def focus(
+    goal: str = typer.Argument(..., help="What you're working on"),
+    body_double: bool = typer.Option(
+        False, "--body-double", "-b", help="Enable body-doubling presence mode"
+    ),
+    duration: int = typer.Option(
+        25, "--duration", "-d", help="Session length in minutes"
+    ),
+    style: str = typer.Option(
+        "variable",
+        "--style",
+        "-s",
+        help="Focus style: hyperfocus, variable, short-burst",
+    ),
+    energy: str = typer.Option(
+        "medium", "--energy", "-e", help="Energy level: low, medium, high"
+    ),
+):
+    """
+    Start a focus session with optional body-doubling presence mode.
+
+    Body doubling provides quiet periodic presence signals — like a
+    study buddy sitting across the table.
+    """
+    from packages.core.agents.focusbuddy import FocusBuddyAgent
+
+    buddy = FocusBuddyAgent()
+
+    if body_double:
+        console.print(
+            f"[bold green]Body-doubling mode[/bold green] — working on '{goal}'"
+        )
+        console.print(
+            f"[dim]Style: {style} | Energy: {energy} | Duration: {duration}min[/dim]\n"
+        )
+        try:
+            elapsed = 0
+            tick = buddy.build_presence_tick(style, energy, elapsed_minutes=elapsed)
+            interval = tick["interval_min"]
+            console.print(
+                f"  [cyan]{tick['message']}[/cyan]  (check-in every {interval}min)"
+            )
+            import time
+
+            while elapsed < duration:
+                time.sleep(min(interval * 60, (duration - elapsed) * 60))
+                elapsed += interval
+                if elapsed >= duration:
+                    break
+                tick = buddy.build_presence_tick(style, energy, elapsed_minutes=elapsed)
+                console.print(
+                    f"  [cyan]{tick['message']}[/cyan]  ({elapsed}/{duration}min)"
+                )
+        except KeyboardInterrupt:
+            pass
+        console.print(
+            f"\n[bold green]Session complete![/bold green] "
+            f"({min(elapsed, duration)}/{duration}min)"
+        )
+    else:
+        console.print(
+            f"[bold green]Focus session[/bold green] — "
+            f"'{goal}' for {duration}min ({style})"
+        )
+        console.print("[dim]Use --body-double for presence mode[/dim]")
+
+
+@app.command()
 def mcp_serve():
     """
     Start proximal as an MCP (Model Context Protocol) server.

--- a/apps/mcp_server.py
+++ b/apps/mcp_server.py
@@ -544,6 +544,53 @@ def _create_mcp_server() -> Any:
             logger.error("plan_from_voice failed: %s", exc, exc_info=True)
             return json.dumps({"error": f"Voice planning failed: {exc}"})
 
+    @server.tool()
+    async def start_body_double(
+        goal: str = "",
+        focus_style: str = "variable",
+        energy: str = "medium",
+        duration_minutes: int = 25,
+    ) -> str:
+        """Start a body-doubling presence session.
+
+        Body doubling provides quiet periodic presence signals — like
+        a study buddy sitting across the table.
+
+        Parameters
+        ----------
+        goal : str
+            What you're working on.
+        focus_style : str
+            Focus style: hyperfocus, variable, or short-burst.
+        energy : str
+            Energy level: low, medium, or high.
+        duration_minutes : int
+            Session length in minutes.
+
+        Returns
+        -------
+        str
+            JSON with presence tick data and session info.
+        """
+        try:
+            from packages.core.agents.focusbuddy import FocusBuddyAgent
+
+            buddy = FocusBuddyAgent()
+            tick = buddy.build_presence_tick(focus_style, energy, elapsed_minutes=0)
+            result = {
+                "goal": goal,
+                "duration_minutes": duration_minutes,
+                "presence_tick": tick,
+                "message": (
+                    f"Body-doubling session started for '{goal}'. "
+                    f"Check in every {tick['interval_min']} minutes."
+                ),
+            }
+            return json.dumps(result)
+        except Exception as exc:
+            logger.error("start_body_double failed: %s", exc, exc_info=True)
+            return json.dumps({"error": f"Body double start failed: {exc}"})
+
     return server
 
 

--- a/apps/server/pipeline.py
+++ b/apps/server/pipeline.py
@@ -57,8 +57,8 @@ async def run_interactive_pipeline(
     -------
     dict
         Pipeline state. If clarification is needed, contains
-        'needs_clarification' and 'clarification_questions'. Otherwise
-        contains 'sprints' with the final plan.
+        'needs_clarification' and 'clarification_questions'. Otherwise contains
+        'sprints' with the final plan.
     """
     state: dict[str, Any] = {"goal": goal, "session_id": session_id, **kwargs}
     state = await clarify_llm(state)

--- a/packages/core/agents/focusbuddy.py
+++ b/packages/core/agents/focusbuddy.py
@@ -99,11 +99,10 @@ class FocusBuddyAgent(BaseAgent):
     async def on_event(self, event) -> None:
         """Handle reactive events from the event bus.
 
-        Subscribed topics:
-        - ``session.task_started`` — emit a mid-session check-in
-        - ``session.task_completed`` — track momentum
-        - ``session.started`` — initialise session tracking
-        - ``session.ended`` — generate retrospective
+        Subscribed topics: - ``session.task_started`` — emit a mid-session
+        check-in - ``session.task_completed`` — track momentum -
+        ``session.started`` — initialise session tracking - ``session.ended`` —
+        generate retrospective
         """
         from ..events import Topics
 
@@ -319,7 +318,7 @@ class FocusBuddyAgent(BaseAgent):
         self._session_start = datetime.now(timezone.utc)
 
     async def _handle_task_completed(self, event) -> None:
-        """Record completion and recalculate momentum."""
+        """Record completion timestamp and increment counter."""
         now = datetime.now(timezone.utc)
         self._completion_times.append(now)
         self._tasks_completed += 1
@@ -503,7 +502,11 @@ class FocusBuddyAgent(BaseAgent):
 
         # timing accuracy
         timing_accuracy = None
-        if estimated_minutes and actual_minutes and estimated_minutes > 0:
+        if (
+            estimated_minutes is not None
+            and actual_minutes is not None
+            and estimated_minutes > 0
+        ):
             timing_accuracy = round(actual_minutes / estimated_minutes, 2)
 
         # restart point

--- a/packages/core/agents/focusbuddy.py
+++ b/packages/core/agents/focusbuddy.py
@@ -94,6 +94,17 @@ class FocusBuddyAgent(BaseAgent):
 
         return create_focus_sessions(tasks)
 
+    # -- reactive event subscriptions ----------------------------------------
+
+    def register_subscriptions(self, bus) -> None:
+        """Wire up event handlers on the given bus."""
+        from ..events import Topics
+
+        bus.subscribe(Topics.SESSION_TASK_STARTED, self.on_event)
+        bus.subscribe(Topics.SESSION_TASK_COMPLETED, self.on_event)
+        bus.subscribe(Topics.SESSION_STARTED, self.on_event)
+        bus.subscribe(Topics.SESSION_ENDED, self.on_event)
+
     # -- reactive event handler (2.1, 2.3, 2.4) -----------------------------
 
     async def on_event(self, event) -> None:

--- a/packages/core/agents/focusbuddy.py
+++ b/packages/core/agents/focusbuddy.py
@@ -1,22 +1,32 @@
 from __future__ import annotations
 
-from typing import Any
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
 
 from .base import BaseAgent
 from .registry import register_agent
 
+logger = logging.getLogger(__name__)
+
 
 @register_agent("focusbuddy")
 class FocusBuddyAgent(BaseAgent):
-    """Create short focus sessions for each task."""
+    """Execution companion — focus sessions, check-ins, transitions,
+    momentum tracking, retrospectives, and body-doubling presence."""
 
     name = "focusbuddy"
 
     def __init__(self) -> None:  # pragma: no cover - trivial
-        pass
+        self._completion_times: list[datetime] = []
+        self._tasks_planned: int = 0
+        self._tasks_completed: int = 0
+        self._session_start: Optional[datetime] = None
 
     def __repr__(self) -> str:  # pragma: no cover - simple representation
         return "FocusBuddyAgent()"
+
+    # -- orchestration entry point -------------------------------------------
 
     async def run(self, context) -> Any:
         """Create focus sessions adapted to energy and user profile."""
@@ -83,3 +93,580 @@ class FocusBuddyAgent(BaseAgent):
         from ..capabilities.productivity import create_focus_sessions
 
         return create_focus_sessions(tasks)
+
+    # -- reactive event handler (2.1, 2.3, 2.4) -----------------------------
+
+    async def on_event(self, event) -> None:
+        """Handle reactive events from the event bus.
+
+        Subscribed topics:
+        - ``session.task_started`` — emit a mid-session check-in
+        - ``session.task_completed`` — track momentum
+        - ``session.started`` — initialise session tracking
+        - ``session.ended`` — generate retrospective
+        """
+        from ..events import Topics
+
+        if event.topic == Topics.SESSION_TASK_STARTED:
+            await self._handle_task_started(event)
+        elif event.topic == Topics.SESSION_TASK_COMPLETED:
+            await self._handle_task_completed(event)
+        elif event.topic == Topics.SESSION_STARTED:
+            self._handle_session_started(event)
+        elif event.topic == Topics.SESSION_ENDED:
+            await self._handle_session_ended(event)
+
+    # -- 2.1  mid-session check-ins -----------------------------------------
+
+    async def _handle_task_started(self, event) -> None:
+        """Emit a check-in event adapted to focus_style and
+        transition_difficulty."""
+        from ..events import Event, Topics, get_event_bus
+
+        data = event.data or {}
+        focus_style = data.get("focus_style", "variable")
+        transition_difficulty = data.get("transition_difficulty", "moderate")
+
+        checkin = self._build_checkin(focus_style, transition_difficulty)
+
+        bus = get_event_bus()
+        await bus.publish(
+            Event(
+                topic=Topics.FOCUSBUDDY_CHECKIN,
+                source="focusbuddy",
+                data=checkin,
+                session_id=event.session_id,
+            )
+        )
+
+    @staticmethod
+    def _build_checkin(
+        focus_style: str,
+        transition_difficulty: str,
+    ) -> dict[str, Any]:
+        """Build check-in payload based on style and difficulty.
+
+        Parameters
+        ----------
+        focus_style : str
+            "hyperfocus", "variable", or "short-burst".
+        transition_difficulty : str
+            "low", "moderate", or "high".
+
+        Returns
+        -------
+        dict
+            Check-in data with message, interval, and intensity.
+        """
+        # base intervals in minutes per style
+        intervals = {
+            "hyperfocus": 45,
+            "variable": 20,
+            "short-burst": 10,
+        }
+        messages = {
+            "hyperfocus": "Still going strong — take a breath when ready.",
+            "variable": "Quick check — how's the focus?",
+            "short-burst": "Session boundary — nice work on that burst.",
+        }
+        intensities = {
+            "hyperfocus": "minimal",
+            "variable": "moderate",
+            "short-burst": "full",
+        }
+
+        interval = intervals.get(focus_style, 20)
+
+        # adjust interval for high transition difficulty
+        if transition_difficulty == "high":
+            interval = max(10, interval - 5)
+        elif transition_difficulty == "low":
+            interval = interval + 5
+
+        return {
+            "message": messages.get(focus_style, messages["variable"]),
+            "interval_min": interval,
+            "intensity": intensities.get(focus_style, "moderate"),
+            "focus_style": focus_style,
+            "transition_difficulty": transition_difficulty,
+        }
+
+    # -- 2.2  transition support ---------------------------------------------
+
+    def build_transition(
+        self,
+        completed_task: str,
+        next_task: str,
+        transition_difficulty: str = "moderate",
+    ) -> dict[str, Any]:
+        """Generate a transition message between tasks.
+
+        Parameters
+        ----------
+        completed_task : str
+            Title of the completed task.
+        next_task : str
+            Title of the upcoming task.
+        transition_difficulty : str
+            "low", "moderate", or "high".
+
+        Returns
+        -------
+        dict
+            Transition data with message, steps, and break recommendation.
+        """
+        if transition_difficulty == "low":
+            return {
+                "message": f"Done with '{completed_task}'. Next up: '{next_task}'.",
+                "steps": [],
+                "break_recommended": False,
+                "difficulty": "low",
+            }
+
+        if transition_difficulty == "high":
+            return {
+                "message": (
+                    f"Great work finishing '{completed_task}'. "
+                    f"Before moving on, take a moment to close "
+                    f"that mental context."
+                ),
+                "steps": [
+                    f"Save or note where you left off on '{completed_task}'",
+                    "Take a 2-3 minute break — stretch, breathe",
+                    f"Preview: '{next_task}' — think about what "
+                    f"you'll need to get started",
+                    "When ready, say 'go' to begin",
+                ],
+                "break_recommended": True,
+                "difficulty": "high",
+            }
+
+        # moderate (default)
+        return {
+            "message": (
+                f"Finished '{completed_task}'. The next task is "
+                f"'{next_task}' — take a breath and shift gears."
+            ),
+            "steps": [
+                f"'{next_task}' involves a context switch — gather what you need first",
+            ],
+            "break_recommended": False,
+            "difficulty": "moderate",
+        }
+
+    async def emit_transition(
+        self,
+        completed_task: str,
+        next_task: str,
+        transition_difficulty: str,
+        context=None,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Build and publish a transition event.
+
+        Also sets or clears ``transition_in_progress`` on the context.
+
+        Parameters
+        ----------
+        completed_task : str
+            Title of the completed task.
+        next_task : str
+            Title of the upcoming task.
+        transition_difficulty : str
+            "low", "moderate", or "high".
+        context : SharedContext or None
+            If provided, sets ``transition_in_progress`` signal.
+        session_id : str or None
+            Session identifier for the event.
+
+        Returns
+        -------
+        dict
+            The transition payload.
+        """
+        from ..events import Event, Topics, get_event_bus
+
+        transition = self.build_transition(
+            completed_task, next_task, transition_difficulty
+        )
+
+        if context is not None:
+            context.set_signal("transition_in_progress", True)
+
+        bus = get_event_bus()
+        await bus.publish(
+            Event(
+                topic=Topics.FOCUSBUDDY_TRANSITION,
+                source="focusbuddy",
+                data=transition,
+                session_id=session_id,
+            )
+        )
+
+        return transition
+
+    def clear_transition(self, context) -> None:
+        """Clear the transition_in_progress signal."""
+        context.set_signal("transition_in_progress", False)
+
+    # -- 2.3  progress momentum tracking ------------------------------------
+
+    def _handle_session_started(self, event) -> None:
+        """Reset tracking state when a new session starts."""
+        self._completion_times = []
+        self._tasks_planned = event.data.get("tasks_planned", 0)
+        self._tasks_completed = 0
+        self._session_start = datetime.now(timezone.utc)
+
+    async def _handle_task_completed(self, event) -> None:
+        """Record completion and recalculate momentum."""
+        now = datetime.now(timezone.utc)
+        self._completion_times.append(now)
+        self._tasks_completed += 1
+
+    def calculate_momentum(
+        self,
+        completion_times: list[datetime] | None = None,
+        *,
+        _now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Calculate momentum from task completion timestamps.
+
+        Parameters
+        ----------
+        completion_times : list[datetime] or None
+            Overrides internal tracking (useful for testing).
+        _now : datetime or None
+            Override current time (testing).
+
+        Returns
+        -------
+        dict
+            Keys: ``tasks_per_hour``, ``trend``, ``signal``.
+        """
+        times = (
+            completion_times if completion_times is not None else self._completion_times
+        )
+
+        if len(times) < 2:
+            return {
+                "tasks_per_hour": 0.0,
+                "trend": "insufficient_data",
+                "signal": None,
+            }
+
+        now = _now or datetime.now(timezone.utc)
+        first = times[0]
+        elapsed_hours = (now - first).total_seconds() / 3600
+        if elapsed_hours <= 0:
+            elapsed_hours = 0.01  # avoid division by zero
+
+        tasks_per_hour = len(times) / elapsed_hours
+
+        # trend from recent half vs first half
+        mid = len(times) // 2
+        if mid < 1:
+            trend = "steady"
+        else:
+            first_half = times[:mid]
+            second_half = times[mid:]
+            first_rate = self._rate(first_half)
+            second_rate = self._rate(second_half)
+            if second_rate > first_rate * 1.2:
+                trend = "accelerating"
+            elif second_rate < first_rate * 0.8:
+                trend = "decelerating"
+            else:
+                trend = "steady"
+
+        # determine signal
+        signal = self._momentum_signal(tasks_per_hour, trend)
+
+        return {
+            "tasks_per_hour": round(tasks_per_hour, 2),
+            "trend": trend,
+            "signal": signal,
+        }
+
+    @staticmethod
+    def _rate(times: list[datetime]) -> float:
+        """Completions per hour within a time slice."""
+        if len(times) < 2:
+            return 1.0
+        span = (times[-1] - times[0]).total_seconds() / 3600
+        if span <= 0:
+            return float(len(times))
+        return len(times) / span
+
+    @staticmethod
+    def _momentum_signal(tasks_per_hour: float, trend: str) -> str | None:
+        """Derive a signal name from momentum metrics."""
+        if trend == "accelerating" and tasks_per_hour >= 1.0:
+            return "momentum_high"
+        if trend == "decelerating" and tasks_per_hour < 1.0:
+            return "momentum_stalling"
+        if trend == "accelerating" and tasks_per_hour < 1.0:
+            return "momentum_recovering"
+        if trend == "steady" and tasks_per_hour >= 2.0:
+            return "momentum_high"
+        return None
+
+    def apply_momentum_signals(self, context) -> dict[str, Any]:
+        """Calculate momentum and set signals on context.
+
+        Parameters
+        ----------
+        context : SharedContext
+            The shared workflow context.
+
+        Returns
+        -------
+        dict
+            The momentum data.
+        """
+        momentum = self.calculate_momentum()
+
+        # clear previous momentum signals
+        for sig in (
+            "momentum_high",
+            "momentum_stalling",
+            "momentum_recovering",
+        ):
+            context.set_signal(sig, False)
+
+        if momentum["signal"]:
+            context.set_signal(momentum["signal"], True)
+
+        return momentum
+
+    # -- 2.4  session retrospective ------------------------------------------
+
+    async def _handle_session_ended(self, event) -> None:
+        """Generate and publish a retrospective on session end."""
+        from ..events import Event, Topics, get_event_bus
+
+        retro = self.build_retrospective(
+            tasks_planned=event.data.get("tasks_planned", self._tasks_planned),
+            tasks_completed=event.data.get("tasks_completed", self._tasks_completed),
+            estimated_minutes=event.data.get("estimated_minutes"),
+            actual_minutes=event.data.get("actual_minutes"),
+            remaining_tasks=event.data.get("remaining_tasks", []),
+            celebration_style=event.data.get("celebration_style", "quiet"),
+        )
+
+        bus = get_event_bus()
+        await bus.publish(
+            Event(
+                topic=Topics.FOCUSBUDDY_RETROSPECTIVE,
+                source="focusbuddy",
+                data=retro,
+                session_id=event.session_id,
+            )
+        )
+
+    @staticmethod
+    def build_retrospective(
+        *,
+        tasks_planned: int = 0,
+        tasks_completed: int = 0,
+        estimated_minutes: float | None = None,
+        actual_minutes: float | None = None,
+        remaining_tasks: list[str] | None = None,
+        celebration_style: str = "quiet",
+    ) -> dict[str, Any]:
+        """Build a structured session retrospective.
+
+        Parameters
+        ----------
+        tasks_planned : int
+            Number of tasks originally planned.
+        tasks_completed : int
+            Number of tasks completed.
+        estimated_minutes : float or None
+            Total estimated time.
+        actual_minutes : float or None
+            Total actual time.
+        remaining_tasks : list[str] or None
+            Titles of unfinished tasks.
+        celebration_style : str
+            "quiet", "enthusiastic", or "data-driven".
+
+        Returns
+        -------
+        dict
+            Retrospective data.
+        """
+        remaining = remaining_tasks or []
+
+        # completion ratio
+        ratio = tasks_completed / tasks_planned if tasks_planned > 0 else 0.0
+
+        # timing accuracy
+        timing_accuracy = None
+        if estimated_minutes and actual_minutes and estimated_minutes > 0:
+            timing_accuracy = round(actual_minutes / estimated_minutes, 2)
+
+        # restart point
+        restart_point = (
+            f"Start with '{remaining[0]}'"
+            if remaining
+            else "All tasks completed — pick a new goal"
+        )
+
+        # celebration message
+        celebration = _celebration_for_retro(ratio, tasks_completed, celebration_style)
+
+        return {
+            "tasks_planned": tasks_planned,
+            "tasks_completed": tasks_completed,
+            "completion_ratio": round(ratio, 2),
+            "timing_accuracy": timing_accuracy,
+            "restart_point": restart_point,
+            "remaining_tasks": remaining,
+            "celebration": celebration,
+            "celebration_style": celebration_style,
+        }
+
+    # -- 2.5  body-doubling presence mode ------------------------------------
+
+    @staticmethod
+    def build_presence_tick(
+        focus_style: str = "variable",
+        energy_level: str = "medium",
+        *,
+        elapsed_minutes: int = 0,
+    ) -> dict[str, Any]:
+        """Build a single presence-mode tick payload.
+
+        Parameters
+        ----------
+        focus_style : str
+            "hyperfocus", "variable", or "short-burst".
+        energy_level : str
+            "low", "medium", or "high".
+        elapsed_minutes : int
+            Minutes elapsed in the session.
+
+        Returns
+        -------
+        dict
+            Presence tick with message, interval, and mode flag.
+        """
+        # interval in minutes between presence signals
+        intervals = {
+            "hyperfocus": 30,
+            "variable": 15,
+            "short-burst": 8,
+        }
+        # low energy = less frequent pings
+        energy_mult = {"low": 1.5, "medium": 1.0, "high": 0.8}
+
+        base_interval = intervals.get(focus_style, 15)
+        mult = energy_mult.get(energy_level, 1.0)
+        interval = max(5, int(base_interval * mult))
+
+        messages = [
+            "Still here with you.",
+            "Working alongside you.",
+            "You're not alone — keep going.",
+            "Right here if you need anything.",
+        ]
+        # rotate message by elapsed time
+        idx = (elapsed_minutes // interval) % len(messages)
+
+        return {
+            "message": messages[idx],
+            "interval_min": interval,
+            "presence_mode": True,
+            "focus_style": focus_style,
+            "energy_level": energy_level,
+            "elapsed_minutes": elapsed_minutes,
+        }
+
+    async def emit_presence_tick(
+        self,
+        focus_style: str = "variable",
+        energy_level: str = "medium",
+        elapsed_minutes: int = 0,
+        session_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Build and publish a presence-mode tick event.
+
+        Parameters
+        ----------
+        focus_style : str
+            "hyperfocus", "variable", or "short-burst".
+        energy_level : str
+            "low", "medium", or "high".
+        elapsed_minutes : int
+            Minutes elapsed in the session.
+        session_id : str or None
+            Session identifier.
+
+        Returns
+        -------
+        dict
+            The presence tick payload.
+        """
+        from ..events import Event, Topics, get_event_bus
+
+        tick = self.build_presence_tick(
+            focus_style, energy_level, elapsed_minutes=elapsed_minutes
+        )
+
+        bus = get_event_bus()
+        await bus.publish(
+            Event(
+                topic=Topics.FOCUSBUDDY_PRESENCE,
+                source="focusbuddy",
+                data=tick,
+                session_id=session_id,
+            )
+        )
+
+        return tick
+
+
+# -- module-level helpers (not methods, to keep class lean) ------------------
+
+
+def _celebration_for_retro(
+    ratio: float,
+    tasks_completed: int,
+    style: str,
+) -> str:
+    """Return a celebration string for the retrospective.
+
+    Parameters
+    ----------
+    ratio : float
+        Completion ratio (0.0 to 1.0+).
+    tasks_completed : int
+        Number completed.
+    style : str
+        "quiet", "enthusiastic", or "data-driven".
+    """
+    if style == "enthusiastic":
+        if ratio >= 1.0:
+            return "You crushed it — every single task done! That's amazing!"
+        if ratio >= 0.5:
+            return (
+                f"Great momentum — {tasks_completed} tasks "
+                f"down! Keep that energy rolling."
+            )
+        return "You showed up and made progress. That matters!"
+
+    if style == "data-driven":
+        pct = int(ratio * 100)
+        return (
+            f"{tasks_completed} tasks completed "
+            f"({pct}% of planned). "
+            f"{'On track.' if ratio >= 0.8 else 'Room to adjust estimates next time.'}"
+        )
+
+    # quiet (default)
+    if ratio >= 1.0:
+        return "All tasks done."
+    if ratio >= 0.5:
+        return f"{tasks_completed} tasks completed. Good session."
+    return "Progress made. Pick up where you left off next time."

--- a/packages/core/events.py
+++ b/packages/core/events.py
@@ -45,6 +45,11 @@ class Topics:
     CHRONOS_RESCHEDULE = "chronos.reschedule"
     CHRONOS_ESTIMATE_LEARNING = "chronos.estimate_learning"
 
+    FOCUSBUDDY_CHECKIN = "focusbuddy.checkin"
+    FOCUSBUDDY_PRESENCE = "focusbuddy.presence"
+    FOCUSBUDDY_TRANSITION = "focusbuddy.transition"
+    FOCUSBUDDY_RETROSPECTIVE = "focusbuddy.retrospective"
+
     CALENDAR_EVENT_CREATED = "calendar.event_created"
     CALENDAR_EVENT_CHANGED = "calendar.event_changed"
     CALENDAR_EVENT_DELETED = "calendar.event_deleted"

--- a/packages/core/startup.py
+++ b/packages/core/startup.py
@@ -53,6 +53,19 @@ def init_reactive_layer() -> EventBus:
     except Exception:
         logger.debug("Failed to register Chronos subscriptions", exc_info=True)
 
+    # wire FocusBuddy subscriptions
+    try:
+        from .agents.focusbuddy import FocusBuddyAgent
+
+        focusbuddy = FocusBuddyAgent()
+        focusbuddy.register_subscriptions(bus)
+        logger.info("FocusBuddy reactive subscriptions registered")
+    except Exception:
+        logger.debug(
+            "Failed to register FocusBuddy subscriptions",
+            exc_info=True,
+        )
+
     # wire notification subscriptions
     try:
         from .notifications.subscribers import register_notification_subscriptions

--- a/tests/README.md
+++ b/tests/README.md
@@ -61,6 +61,12 @@ pip install -e ".[dev]"
 | `test_planner_profile.py`    | `decision_fatigue` task capping, priority sorting                         |
 | `test_signal_wiring.py`      | `low_energy_mode` and `deadline_at_risk` signal propagation across agents |
 
+### Agents (execution layer)
+
+| File                            | What it tests                                                                      |
+| ------------------------------- | ---------------------------------------------------------------------------------- |
+| `test_focusbuddy_execution.py`  | Mid-session check-ins, transitions, momentum tracking, retrospectives, presence mode |
+
 ### Orchestration & workflows
 
 | File                      | What it tests                               |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -197,11 +197,41 @@ def test_plan_interactive_direct_mode_needs_clarification(mock_pipeline, runner)
         "goal": "Build an app",
     }
 
-    # this will fail because Prompt.ask is not mocked, but the pipeline call should happen
-    # we test the non-interactive path separately
+    # this will fail because Prompt.ask is not mocked, but the pipeline call
+    # should happen we test the non-interactive path separately
     result = runner.invoke(
         app, ["plan", "Build an app", "--interactive", "--no-pretty"], input="iOS\n"
     )
 
     # the interactive flow should have started
     assert "Interactive Planning" in result.stdout
+
+
+def test_focus_command_basic(runner):
+    """focus command without body-double prints session info."""
+    result = runner.invoke(app, ["focus", "Write docs"])
+    assert result.exit_code == 0
+    assert "Write docs" in result.stdout
+    assert "--body-double" in result.stdout
+
+
+@patch("apps.cli.time.sleep", side_effect=KeyboardInterrupt)
+def test_focus_body_double_interrupted(mock_sleep, runner):
+    """focus --body-double exits cleanly on ctrl-c."""
+    result = runner.invoke(
+        app,
+        ["focus", "Deep work", "--body-double", "--duration", "10"],
+    )
+    assert result.exit_code == 0
+    assert "Body-doubling mode" in result.stdout
+    assert "Deep work" in result.stdout
+
+
+def test_focus_body_double_zero_duration(runner):
+    """focus --body-double with zero duration exits immediately."""
+    result = runner.invoke(
+        app,
+        ["focus", "Quick check", "--body-double", "--duration", "0"],
+    )
+    assert result.exit_code == 0
+    assert "Session complete" in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -227,11 +227,10 @@ def test_focus_body_double_interrupted(mock_sleep, runner):
     assert "Deep work" in result.stdout
 
 
-def test_focus_body_double_zero_duration(runner):
-    """focus --body-double with zero duration exits immediately."""
+def test_focus_body_double_invalid_duration(runner):
+    """focus --body-double rejects duration < 1."""
     result = runner.invoke(
         app,
         ["focus", "Quick check", "--body-double", "--duration", "0"],
     )
-    assert result.exit_code == 0
-    assert "Session complete" in result.stdout
+    assert result.exit_code != 0

--- a/tests/test_focusbuddy_execution.py
+++ b/tests/test_focusbuddy_execution.py
@@ -1,0 +1,593 @@
+"""Tests for Phase 2: FocusBuddy execution-layer features.
+
+Covers:
+- 2.1 mid-session check-ins
+- 2.2 transition support
+- 2.3 progress momentum tracking
+- 2.4 session retrospective
+- 2.5 body-doubling presence mode
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from packages.core.agents.focusbuddy import FocusBuddyAgent, _celebration_for_retro
+from packages.core.collaboration.context import SharedContext
+from packages.core.events import Event, EventBus, Topics, reset_event_bus
+
+
+@pytest.fixture(autouse=True)
+def _clean_bus():
+    """reset global event bus between tests"""
+    reset_event_bus()
+    yield
+    reset_event_bus()
+
+
+@pytest.fixture
+def buddy():
+    return FocusBuddyAgent()
+
+
+@pytest.fixture
+def ctx():
+    return SharedContext(goal="test goal", tasks=[{"title": "task-a"}])
+
+
+# -----------------------------------------------------------------------
+# 2.1  mid-session check-ins
+# -----------------------------------------------------------------------
+
+
+class TestCheckinEvents:
+    """FocusBuddy emits FOCUSBUDDY_CHECKIN on SESSION_TASK_STARTED."""
+
+    async def test_checkin_emitted_on_task_started(self, buddy):
+        """check-in event is published when a task starts"""
+        bus = EventBus()
+        received = []
+
+        async def capture(evt):
+            received.append(evt)
+
+        bus.subscribe(Topics.FOCUSBUDDY_CHECKIN, capture)
+
+        # patch get_event_bus to return our local bus
+        import packages.core.events as ev_mod
+
+        original = ev_mod.get_event_bus
+        ev_mod.get_event_bus = lambda: bus
+        try:
+            event = Event(
+                topic=Topics.SESSION_TASK_STARTED,
+                source="test",
+                data={"focus_style": "variable", "transition_difficulty": "moderate"},
+            )
+            await buddy.on_event(event)
+        finally:
+            ev_mod.get_event_bus = original
+
+        assert len(received) == 1
+        assert received[0].topic == Topics.FOCUSBUDDY_CHECKIN
+        assert received[0].data["focus_style"] == "variable"
+
+    def test_checkin_hyperfocus_minimal(self, buddy):
+        """hyperfocus style produces minimal intensity with long interval"""
+        checkin = buddy._build_checkin("hyperfocus", "moderate")
+        assert checkin["intensity"] == "minimal"
+        assert checkin["interval_min"] >= 40
+
+    def test_checkin_shortburst_full(self, buddy):
+        """short-burst style produces full intensity with short interval"""
+        checkin = buddy._build_checkin("short-burst", "moderate")
+        assert checkin["intensity"] == "full"
+        assert checkin["interval_min"] <= 12
+
+    def test_checkin_variable_moderate(self, buddy):
+        """variable style produces moderate intensity"""
+        checkin = buddy._build_checkin("variable", "moderate")
+        assert checkin["intensity"] == "moderate"
+        assert 15 <= checkin["interval_min"] <= 25
+
+    def test_checkin_high_transition_shorter_interval(self, buddy):
+        """high transition difficulty shortens check-in interval"""
+        normal = buddy._build_checkin("variable", "moderate")
+        high = buddy._build_checkin("variable", "high")
+        assert high["interval_min"] < normal["interval_min"]
+
+    def test_checkin_low_transition_longer_interval(self, buddy):
+        """low transition difficulty lengthens check-in interval"""
+        normal = buddy._build_checkin("variable", "moderate")
+        low = buddy._build_checkin("variable", "low")
+        assert low["interval_min"] > normal["interval_min"]
+
+    def test_checkin_has_message(self, buddy):
+        """every check-in has a non-empty message"""
+        for style in ("hyperfocus", "variable", "short-burst"):
+            checkin = buddy._build_checkin(style, "moderate")
+            assert checkin["message"]
+
+
+# -----------------------------------------------------------------------
+# 2.2  transition support
+# -----------------------------------------------------------------------
+
+
+class TestTransitionSupport:
+    """Transition messages between tasks scaled by difficulty."""
+
+    def test_low_difficulty_brief(self, buddy):
+        """low difficulty produces a brief single-line transition"""
+        t = buddy.build_transition("task-a", "task-b", "low")
+        assert t["difficulty"] == "low"
+        assert not t["break_recommended"]
+        assert len(t["steps"]) == 0
+        assert "task-a" in t["message"]
+        assert "task-b" in t["message"]
+
+    def test_moderate_difficulty_has_steps(self, buddy):
+        """moderate difficulty includes one step"""
+        t = buddy.build_transition("task-a", "task-b", "moderate")
+        assert t["difficulty"] == "moderate"
+        assert len(t["steps"]) == 1
+        assert not t["break_recommended"]
+
+    def test_high_difficulty_full_ritual(self, buddy):
+        """high difficulty provides full transition ritual with break"""
+        t = buddy.build_transition("task-a", "task-b", "high")
+        assert t["difficulty"] == "high"
+        assert t["break_recommended"]
+        assert len(t["steps"]) >= 3
+        assert any("break" in s.lower() for s in t["steps"])
+
+    async def test_emit_transition_sets_signal(self, buddy, ctx):
+        """emit_transition sets transition_in_progress on context"""
+        import packages.core.events as ev_mod
+
+        bus = EventBus()
+        original = ev_mod.get_event_bus
+        ev_mod.get_event_bus = lambda: bus
+        try:
+            await buddy.emit_transition(
+                "task-a", "task-b", "moderate", context=ctx
+            )
+        finally:
+            ev_mod.get_event_bus = original
+
+        assert ctx.get_signal("transition_in_progress") is True
+
+    async def test_emit_transition_publishes_event(self, buddy, ctx):
+        """emit_transition publishes a FOCUSBUDDY_TRANSITION event"""
+        import packages.core.events as ev_mod
+
+        bus = EventBus()
+        received = []
+
+        async def capture(evt):
+            received.append(evt)
+
+        bus.subscribe(Topics.FOCUSBUDDY_TRANSITION, capture)
+
+        original = ev_mod.get_event_bus
+        ev_mod.get_event_bus = lambda: bus
+        try:
+            await buddy.emit_transition(
+                "task-a", "task-b", "high", context=ctx
+            )
+        finally:
+            ev_mod.get_event_bus = original
+
+        assert len(received) == 1
+        assert received[0].data["difficulty"] == "high"
+
+    def test_clear_transition(self, buddy, ctx):
+        """clear_transition resets the signal"""
+        ctx.set_signal("transition_in_progress", True)
+        buddy.clear_transition(ctx)
+        assert ctx.get_signal("transition_in_progress") is False
+
+
+# -----------------------------------------------------------------------
+# 2.3  progress momentum tracking
+# -----------------------------------------------------------------------
+
+
+class TestMomentumTracking:
+    """Momentum calculation from task completion timestamps."""
+
+    def test_insufficient_data(self, buddy):
+        """fewer than 2 completions returns insufficient_data"""
+        m = buddy.calculate_momentum([])
+        assert m["trend"] == "insufficient_data"
+        assert m["signal"] is None
+
+        m2 = buddy.calculate_momentum([datetime.now(timezone.utc)])
+        assert m2["trend"] == "insufficient_data"
+
+    def test_steady_momentum(self, buddy):
+        """evenly spaced completions produce steady trend"""
+        base = datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc)
+        times = [base + timedelta(minutes=15 * i) for i in range(6)]
+        now = times[-1] + timedelta(minutes=1)
+        m = buddy.calculate_momentum(times, _now=now)
+        assert m["trend"] == "steady"
+        assert m["tasks_per_hour"] > 0
+
+    def test_accelerating_momentum(self, buddy):
+        """faster completions in second half produce accelerating trend"""
+        base = datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc)
+        # first half: 30 min apart; second half: 5 min apart
+        times = [
+            base,
+            base + timedelta(minutes=30),
+            base + timedelta(minutes=60),
+            base + timedelta(minutes=65),
+            base + timedelta(minutes=70),
+            base + timedelta(minutes=75),
+        ]
+        now = times[-1] + timedelta(minutes=1)
+        m = buddy.calculate_momentum(times, _now=now)
+        assert m["trend"] == "accelerating"
+
+    def test_decelerating_momentum(self, buddy):
+        """slower completions in second half produce decelerating trend"""
+        base = datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc)
+        # first half: 5 min apart; second half: 30 min apart
+        times = [
+            base,
+            base + timedelta(minutes=5),
+            base + timedelta(minutes=10),
+            base + timedelta(minutes=40),
+            base + timedelta(minutes=70),
+            base + timedelta(minutes=100),
+        ]
+        now = times[-1] + timedelta(minutes=1)
+        m = buddy.calculate_momentum(times, _now=now)
+        assert m["trend"] == "decelerating"
+
+    def test_momentum_high_signal(self, buddy):
+        """high rate + accelerating = momentum_high signal"""
+        base = datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc)
+        times = [
+            base,
+            base + timedelta(minutes=20),
+            base + timedelta(minutes=40),
+            base + timedelta(minutes=45),
+            base + timedelta(minutes=48),
+            base + timedelta(minutes=50),
+        ]
+        now = times[-1] + timedelta(minutes=1)
+        m = buddy.calculate_momentum(times, _now=now)
+        assert m["signal"] in ("momentum_high", "momentum_recovering")
+
+    def test_momentum_stalling_signal(self, buddy):
+        """low rate + decelerating = momentum_stalling"""
+        base = datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc)
+        times = [
+            base,
+            base + timedelta(minutes=10),
+            base + timedelta(minutes=80),
+            base + timedelta(minutes=160),
+        ]
+        now = times[-1] + timedelta(hours=2)
+        m = buddy.calculate_momentum(times, _now=now)
+        assert m["trend"] == "decelerating"
+        assert m["signal"] == "momentum_stalling"
+
+    def test_apply_momentum_signals_sets_context(self, buddy, ctx):
+        """apply_momentum_signals sets the correct signal on context"""
+        base = datetime(2026, 3, 5, 10, 0, tzinfo=timezone.utc)
+        buddy._completion_times = [
+            base,
+            base + timedelta(minutes=10),
+            base + timedelta(minutes=80),
+            base + timedelta(minutes=160),
+        ]
+        momentum = buddy.apply_momentum_signals(ctx)
+        # at least one signal should be set or all false
+        assert "signal" in momentum
+
+    def test_apply_momentum_clears_previous(self, buddy, ctx):
+        """previous momentum signals are cleared before setting new ones"""
+        ctx.set_signal("momentum_high", True)
+        buddy._completion_times = []
+        buddy.apply_momentum_signals(ctx)
+        assert ctx.get_signal("momentum_high") is False
+
+
+# -----------------------------------------------------------------------
+# 2.4  session retrospective
+# -----------------------------------------------------------------------
+
+
+class TestSessionRetrospective:
+    """Retrospective generation on session end."""
+
+    def test_full_completion(self, buddy):
+        """all tasks done produces 1.0 ratio"""
+        retro = buddy.build_retrospective(
+            tasks_planned=5, tasks_completed=5
+        )
+        assert retro["completion_ratio"] == 1.0
+        assert retro["restart_point"] == "All tasks completed — pick a new goal"
+
+    def test_partial_completion(self, buddy):
+        """partial completion produces correct ratio and restart point"""
+        retro = buddy.build_retrospective(
+            tasks_planned=4,
+            tasks_completed=2,
+            remaining_tasks=["task-c", "task-d"],
+        )
+        assert retro["completion_ratio"] == 0.5
+        assert "task-c" in retro["restart_point"]
+
+    def test_timing_accuracy(self, buddy):
+        """timing accuracy is actual / estimated"""
+        retro = buddy.build_retrospective(
+            tasks_planned=3,
+            tasks_completed=3,
+            estimated_minutes=60,
+            actual_minutes=72,
+        )
+        assert retro["timing_accuracy"] == 1.2
+
+    def test_celebration_quiet(self, buddy):
+        """quiet celebration style produces understated message"""
+        retro = buddy.build_retrospective(
+            tasks_planned=3, tasks_completed=3, celebration_style="quiet"
+        )
+        assert "All tasks done" in retro["celebration"]
+
+    def test_celebration_enthusiastic(self, buddy):
+        """enthusiastic style produces energetic message"""
+        retro = buddy.build_retrospective(
+            tasks_planned=3,
+            tasks_completed=3,
+            celebration_style="enthusiastic",
+        )
+        assert "crushed" in retro["celebration"].lower() or "amazing" in retro["celebration"].lower()
+
+    def test_celebration_data_driven(self, buddy):
+        """data-driven style includes percentage"""
+        retro = buddy.build_retrospective(
+            tasks_planned=4,
+            tasks_completed=3,
+            celebration_style="data-driven",
+        )
+        assert "75%" in retro["celebration"]
+        assert "3 tasks" in retro["celebration"]
+
+    async def test_session_ended_emits_retrospective(self, buddy):
+        """SESSION_ENDED triggers a FOCUSBUDDY_RETROSPECTIVE event"""
+        import packages.core.events as ev_mod
+
+        bus = EventBus()
+        received = []
+
+        async def capture(evt):
+            received.append(evt)
+
+        bus.subscribe(Topics.FOCUSBUDDY_RETROSPECTIVE, capture)
+
+        original = ev_mod.get_event_bus
+        ev_mod.get_event_bus = lambda: bus
+        try:
+            event = Event(
+                topic=Topics.SESSION_ENDED,
+                source="test",
+                data={
+                    "tasks_planned": 3,
+                    "tasks_completed": 2,
+                    "remaining_tasks": ["task-c"],
+                    "celebration_style": "quiet",
+                },
+            )
+            await buddy.on_event(event)
+        finally:
+            ev_mod.get_event_bus = original
+
+        assert len(received) == 1
+        assert received[0].data["completion_ratio"] == pytest.approx(0.67, abs=0.01)
+        assert "task-c" in received[0].data["restart_point"]
+
+    def test_zero_planned_tasks(self, buddy):
+        """zero planned tasks doesn't divide by zero"""
+        retro = buddy.build_retrospective(tasks_planned=0, tasks_completed=0)
+        assert retro["completion_ratio"] == 0.0
+
+
+# -----------------------------------------------------------------------
+# 2.5  body-doubling presence mode
+# -----------------------------------------------------------------------
+
+
+class TestPresenceMode:
+    """Body-doubling presence tick generation."""
+
+    def test_presence_tick_has_required_keys(self, buddy):
+        """tick payload contains all expected keys"""
+        tick = buddy.build_presence_tick("variable", "medium")
+        assert tick["presence_mode"] is True
+        assert "message" in tick
+        assert "interval_min" in tick
+        assert tick["focus_style"] == "variable"
+
+    def test_hyperfocus_longer_interval(self, buddy):
+        """hyperfocus style results in longer presence intervals"""
+        hyper = buddy.build_presence_tick("hyperfocus", "medium")
+        variable = buddy.build_presence_tick("variable", "medium")
+        assert hyper["interval_min"] > variable["interval_min"]
+
+    def test_shortburst_shorter_interval(self, buddy):
+        """short-burst style results in shorter presence intervals"""
+        short = buddy.build_presence_tick("short-burst", "medium")
+        variable = buddy.build_presence_tick("variable", "medium")
+        assert short["interval_min"] < variable["interval_min"]
+
+    def test_low_energy_increases_interval(self, buddy):
+        """low energy increases interval (less frequent pings)"""
+        low = buddy.build_presence_tick("variable", "low")
+        medium = buddy.build_presence_tick("variable", "medium")
+        assert low["interval_min"] >= medium["interval_min"]
+
+    def test_high_energy_decreases_interval(self, buddy):
+        """high energy decreases interval (more frequent pings)"""
+        high = buddy.build_presence_tick("variable", "high")
+        medium = buddy.build_presence_tick("variable", "medium")
+        assert high["interval_min"] <= medium["interval_min"]
+
+    def test_message_rotates_with_elapsed(self, buddy):
+        """presence messages rotate as time passes"""
+        tick0 = buddy.build_presence_tick(
+            "variable", "medium", elapsed_minutes=0
+        )
+        tick1 = buddy.build_presence_tick(
+            "variable", "medium", elapsed_minutes=15
+        )
+        tick2 = buddy.build_presence_tick(
+            "variable", "medium", elapsed_minutes=30
+        )
+        # at least two of three should differ (rotation)
+        messages = {tick0["message"], tick1["message"], tick2["message"]}
+        assert len(messages) >= 2
+
+    async def test_emit_presence_publishes_event(self, buddy):
+        """emit_presence_tick publishes FOCUSBUDDY_PRESENCE event"""
+        import packages.core.events as ev_mod
+
+        bus = EventBus()
+        received = []
+
+        async def capture(evt):
+            received.append(evt)
+
+        bus.subscribe(Topics.FOCUSBUDDY_PRESENCE, capture)
+
+        original = ev_mod.get_event_bus
+        ev_mod.get_event_bus = lambda: bus
+        try:
+            await buddy.emit_presence_tick(
+                "variable", "medium", elapsed_minutes=0
+            )
+        finally:
+            ev_mod.get_event_bus = original
+
+        assert len(received) == 1
+        assert received[0].data["presence_mode"] is True
+
+    def test_interval_minimum_floor(self, buddy):
+        """interval never goes below 5 minutes"""
+        tick = buddy.build_presence_tick(
+            "short-burst", "high", elapsed_minutes=0
+        )
+        assert tick["interval_min"] >= 5
+
+
+# -----------------------------------------------------------------------
+# celebration helper
+# -----------------------------------------------------------------------
+
+
+class TestCelebrationHelper:
+    """_celebration_for_retro module-level helper."""
+
+    def test_enthusiastic_full(self):
+        assert "crush" in _celebration_for_retro(1.0, 5, "enthusiastic").lower()
+
+    def test_enthusiastic_partial(self):
+        msg = _celebration_for_retro(0.6, 3, "enthusiastic")
+        assert "3 tasks" in msg
+
+    def test_enthusiastic_low(self):
+        msg = _celebration_for_retro(0.2, 1, "enthusiastic")
+        assert "progress" in msg.lower()
+
+    def test_data_driven_on_track(self):
+        msg = _celebration_for_retro(0.9, 9, "data-driven")
+        assert "On track" in msg
+
+    def test_data_driven_room_to_adjust(self):
+        msg = _celebration_for_retro(0.5, 3, "data-driven")
+        assert "adjust" in msg.lower()
+
+    def test_quiet_full(self):
+        assert "All tasks done" in _celebration_for_retro(1.0, 5, "quiet")
+
+    def test_quiet_partial(self):
+        msg = _celebration_for_retro(0.6, 3, "quiet")
+        assert "3 tasks" in msg
+
+    def test_quiet_low(self):
+        msg = _celebration_for_retro(0.2, 1, "quiet")
+        assert "pick up" in msg.lower()
+
+
+# -----------------------------------------------------------------------
+# on_event routing
+# -----------------------------------------------------------------------
+
+
+class TestEventRouting:
+    """on_event correctly dispatches to sub-handlers."""
+
+    async def test_session_started_resets_state(self, buddy):
+        """SESSION_STARTED resets internal tracking"""
+        buddy._tasks_completed = 5
+        buddy._completion_times = [datetime.now(timezone.utc)]
+
+        event = Event(
+            topic=Topics.SESSION_STARTED,
+            source="test",
+            data={"tasks_planned": 3},
+        )
+        await buddy.on_event(event)
+
+        assert buddy._tasks_planned == 3
+        assert buddy._tasks_completed == 0
+        assert buddy._completion_times == []
+
+    async def test_task_completed_tracks(self, buddy):
+        """SESSION_TASK_COMPLETED increments tracking"""
+        event = Event(
+            topic=Topics.SESSION_TASK_COMPLETED,
+            source="test",
+            data={},
+        )
+        await buddy.on_event(event)
+        assert buddy._tasks_completed == 1
+        assert len(buddy._completion_times) == 1
+
+    async def test_unknown_event_ignored(self, buddy):
+        """unhandled topics are silently ignored"""
+        event = Event(
+            topic="some.unknown.topic",
+            source="test",
+            data={},
+        )
+        # should not raise
+        await buddy.on_event(event)
+
+
+# -----------------------------------------------------------------------
+# mentor reads momentum signals (2.3 cross-agent)
+# -----------------------------------------------------------------------
+
+
+class TestMentorMomentumResponse:
+    """Mentor adapts to momentum signals set by FocusBuddy."""
+
+    async def test_mentor_acknowledges_momentum_high(self):
+        """mentor output differs when momentum_high is set"""
+        from packages.core.agents.mentor import MentorAgent
+
+        mentor = MentorAgent()
+        ctx = SharedContext(goal="ship feature")
+        ctx.set_signal("momentum_high", True)
+
+        result = await mentor.run(ctx)
+        # mentor should still produce output (it doesn't crash)
+        assert isinstance(result, str)
+        assert len(result) > 0

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -297,11 +297,8 @@ async def test_draft_message_invalid_json_from_llm(mock_get_chat):
 
 
 @pytest.mark.asyncio
-async def test_start_body_double_returns_presence_tick():
-    """start_body_double returns goal, duration, and presence tick."""
-    # import the handler directly — no LLM mock needed
-
-    # call the underlying focusbuddy logic directly
+async def test_focusbuddy_build_presence_tick():
+    """build_presence_tick returns presence mode, interval, and style."""
     from packages.core.agents.focusbuddy import FocusBuddyAgent
 
     buddy = FocusBuddyAgent()
@@ -313,8 +310,8 @@ async def test_start_body_double_returns_presence_tick():
 
 
 @pytest.mark.asyncio
-async def test_start_body_double_adapts_to_style():
-    """body-double presence tick adapts interval to focus style."""
+async def test_focusbuddy_presence_tick_adapts_to_style():
+    """build_presence_tick adapts interval to focus style."""
     from packages.core.agents.focusbuddy import FocusBuddyAgent
 
     buddy = FocusBuddyAgent()

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -294,3 +294,31 @@ async def test_draft_message_invalid_json_from_llm(mock_get_chat):
 
     # should still produce a result using the raw text as body
     assert "subject" in data or "error" in data
+
+
+@pytest.mark.asyncio
+async def test_start_body_double_returns_presence_tick():
+    """start_body_double returns goal, duration, and presence tick."""
+    # import the handler directly — no LLM mock needed
+
+    # call the underlying focusbuddy logic directly
+    from packages.core.agents.focusbuddy import FocusBuddyAgent
+
+    buddy = FocusBuddyAgent()
+    tick = buddy.build_presence_tick("variable", "medium", elapsed_minutes=0)
+
+    assert tick["presence_mode"] is True
+    assert "interval_min" in tick
+    assert tick["focus_style"] == "variable"
+
+
+@pytest.mark.asyncio
+async def test_start_body_double_adapts_to_style():
+    """body-double presence tick adapts interval to focus style."""
+    from packages.core.agents.focusbuddy import FocusBuddyAgent
+
+    buddy = FocusBuddyAgent()
+    hyper = buddy.build_presence_tick("hyperfocus", "medium")
+    short = buddy.build_presence_tick("short-burst", "medium")
+
+    assert hyper["interval_min"] > short["interval_min"]


### PR DESCRIPTION
* Upgrade FocusBuddy from simple session creation to an event-driven execution companion
* Add event topics for check-ins, transitions, retrospectives, and presence ticks
* Introduce body-doubling presence mode via CLI (`proximal focus --body-double`) and MCP tool (`start_body_double`)
* Track momentum and generate session retrospectives with celebration styles and restart points